### PR TITLE
Add exception helpers

### DIFF
--- a/pakkr/exception.py
+++ b/pakkr/exception.py
@@ -1,0 +1,57 @@
+import sys
+import traceback
+from contextlib import contextmanager
+from itertools import chain
+
+
+@contextmanager
+def exception_handler(exc_handler):
+    "Sets a custom exception handler for the scope of a 'with' block."
+    sys.excepthook = exc_handler
+    try:
+        yield
+    finally:
+        sys.excepthook = sys.__excepthook__
+
+
+def pakkr_exchandler(_type, ex, tb):
+    cause = ex.__cause__
+    if cause:
+        traceback.print_exception(_type, cause, cause.__traceback__, chain=False)
+        print(ex.pakkr_stacks())
+    else:
+        traceback.print_exception(_type, ex, ex.__traceback__, chain=False)
+
+
+class PakkrError(Exception):
+    def __init__(self, message, stack=None):
+        self._message = message
+        self._stacks = [stack] if stack else []
+        super(PakkrError, self).__init__(message, stack)
+
+    def append_stack(self, stack):
+        self._stacks.append(stack)
+        return self
+
+    def __str__(self):
+        return self._message + '\n' + self.pakkr_stacks()
+
+    def pakkr_stacks(self):
+        return '\n'.join(self._stacks)
+
+
+def exception_context(identifier, arg, opts, meta):
+    called_with = ', '.join(chain([str(type(v)) for v in arg],
+                                  ['{}={}'.format(k, type(v)) for k, v in opts.items()]))
+    available_meta = ''
+    if meta:
+        available_meta = '\n\t\tavailable meta {}'.format(summarise_dictionary(meta))
+
+    return '\tinside {identifier} executed with ({called_with}){available_meta}'.format(
+        identifier=identifier,
+        called_with=called_with,
+        available_meta=available_meta)
+
+
+def summarise_dictionary(obj):
+    return '{{{}}}'.format(', '.join(['{}: {}'.format(k, type(v)) for k, v in obj.items()]))

--- a/pakkr/exception_test.py
+++ b/pakkr/exception_test.py
@@ -1,0 +1,66 @@
+import sys
+from collections import OrderedDict
+from pakkr.exception import (exception_context,
+                             exception_handler,
+                             PakkrError,
+                             pakkr_exchandler,
+                             summarise_dictionary)
+from mock import DEFAULT, patch, MagicMock, PropertyMock
+
+
+def test_summarise_dictionary():
+    ordered_dict = OrderedDict([("a", 1), ("b", "hello"), ("c", {"d": 1}), ("d", [1, 2])])
+    actual = summarise_dictionary(ordered_dict)
+    assert actual == "{a: <class 'int'>, b: <class 'str'>, c: <class 'dict'>, d: <class 'list'>}"
+
+
+def test_exception_context():
+    assert exception_context('"my_step"<StepClass>',
+                             [1, "a"],
+                             {"numbers": [1, 2]}, {"dictionary": {"x": 1, "y": 2}}) \
+        == \
+        ("\tinside \"my_step\"<StepClass> executed with "
+         "(<class 'int'>, <class 'str'>, numbers=<class 'list'>)\n"
+         "\t\tavailable meta {dictionary: <class 'dict'>}")
+
+
+def test_exception_handler():
+    mock_handler = MagicMock()
+    with exception_handler(mock_handler):
+        assert sys.excepthook == mock_handler
+    assert sys.excepthook == sys.__excepthook__
+
+
+def test_pakkr_exchandler():
+    mock_ex = MagicMock()
+    mock_ex.__cause__ = None
+    mock_ex.__traceback__ = PropertyMock()
+
+    with patch("pakkr.exception.traceback") as mock_traceback:
+        pakkr_exchandler(MagicMock, mock_ex, None)
+        mock_traceback.print_exception.assert_called_with(MagicMock,
+                                                          mock_ex,
+                                                          mock_ex.__traceback__,
+                                                          chain=False)
+
+    mock_ex.__cause__ = PropertyMock()
+    mock_ex.__cause__.__traceback__ = PropertyMock
+    with patch.multiple("pakkr.exception", traceback=DEFAULT,
+                                           print=DEFAULT) as mocks:  # noqa: E999
+        mock_traceback = mocks['traceback']
+        mock_print = mocks['print']
+
+        pakkr_exchandler(MagicMock, mock_ex, None)
+        mock_traceback.print_exception.assert_called_with(MagicMock,
+                                                          mock_ex.__cause__,
+                                                          mock_ex.__cause__.__traceback__,
+                                                          chain=False)
+        mock_ex.pakkr_stacks.assert_called_once()
+        mock_print.assert_called_with(mock_ex.pakkr_stacks.return_value)
+
+
+def test_pakkr_error():
+    error = PakkrError("some error", "stack #1")
+    error.append_stack("stack #2")
+
+    assert str(error) == "some error\nstack #1\nstack #2"


### PR DESCRIPTION
Add `PakkrError` class and some exception handlers to record and print context of around the exception, such as what parameters were used to execute the pipeline etc.

More or less the same as the previous one in the internal version of Pakkr.

cc @zendesk/numbats 