### PR TITLE
Use inspect.signature() in Pipeline

### DIFF
--- a/pakkr/pipeline_test.py
+++ b/pakkr/pipeline_test.py
@@ -126,16 +126,6 @@ def test_step_instance_method():
     assert pipeline(100) == "100"
 
 def test_step_class_method():
-    @returns(str, a=bool)
-    class Step:
-        @classmethod
-        def __call__(cls, x):
-            return str(x), {'a': False}
-
-    pipeline = Pipeline(Step())
-    assert pipeline(x=100) == "100"
-    assert pipeline(100) == "100"
-
     class Step:
         @classmethod
         @returns(str, a=bool)
@@ -148,16 +138,6 @@ def test_step_class_method():
 
 
 def test_step_static_method():
-    @returns(str, a=bool)
-    class Step:
-        @staticmethod
-        def __call__(x):
-            return str(x), {'a': False}
-
-    pipeline = Pipeline(Step())
-    assert pipeline(x=100) == "100"
-    assert pipeline(100) == "100"
-
     class Step:
         @staticmethod
         @returns(str, a=bool)


### PR DESCRIPTION
`inspect.signature()` is a much nicer way to deal with function arguments and it deals with bound method as well, i.e. skipping `self`/`cls` for instance/class methods.

cc @zendesk/numbats 