### PR TITLE
Allow suppressing timing logs

### DIFF
--- a/pakkr/logging.py
+++ b/pakkr/logging.py
@@ -13,9 +13,12 @@ class IndentationAdapter(logging.LoggerAdapter):
 
 
 @contextmanager
-def log_timing(logger):
-    logger.info("starting")
-    start_time = time.time()
-    yield
-    end_time = time.time()
-    logger.info("finished (took {elapsed:.3f}s)".format(elapsed=end_time - start_time))
+def log_timing(logger, suppressd=False):
+    if suppressd:
+        yield
+    else:
+        logger.info("starting")
+        start_time = time.time()
+        yield
+        end_time = time.time()
+        logger.info("finished (took {elapsed:.3f}s)".format(elapsed=end_time - start_time))

--- a/pakkr/logging_test.py
+++ b/pakkr/logging_test.py
@@ -20,3 +20,12 @@ def test_log_timing(mock_time):
 
     mock_step.run.assert_called_with(x=1)
     mock_logger.info.assert_has_calls([call("starting"), call("finished (took 8.000s)")])
+
+
+def test_log_timing_suppressed():
+    mock_logger = MagicMock()
+    mock_step = MagicMock()
+    with log_timing(mock_logger, True):
+        mock_step.run(x=1)
+    mock_step.run.assert_called_with(x=1)
+    mock_logger.assert_not_called()


### PR DESCRIPTION
Add option to suppress the timing logs, mainly for the case where a pipeline is being called in a loop and produce a large amount of timing logs.

@zendesk/numbats 