### PR TITLE
Fix _run_step indentation

### DIFF
--- a/pakkr/pipeline.py
+++ b/pakkr/pipeline.py
@@ -46,7 +46,7 @@ class Pipeline:
 
         try:
             with log_timing(logger, self._suppress_timing_logs):
-                partial_run_step = partial(self._run_step, indent=depth)
+                partial_run_step = partial(self._run_step, indent=depth + 1)
                 new_arg, _ = reduce(partial_run_step, self._steps, (args, meta))
                 new_arg, new_meta = self._filter_results((new_arg, self._meta))
         except PakkrError as e:

--- a/pakkr/pipeline_test.py
+++ b/pakkr/pipeline_test.py
@@ -46,6 +46,17 @@ def test_pipeline():
     assert pipeline(offset=1) == "world"
 
 
+def test_pipeline_run_step():
+    def say_hello():
+        return "hello"
+
+    pipeline = Pipeline(say_hello)
+
+    with patch.object(pipeline, '_run_step', wraps=pipeline._run_step) as spy:
+        pipeline()
+        spy.assert_called_with(((), {}), say_hello, indent=1)
+
+
 def test_pipeline_step_exception():
     def throw():
         raise Exception("something is wrong")


### PR DESCRIPTION
Step logging should have been 1 level deeper that its pipeline.

cc @zendesk/numbats 